### PR TITLE
Adds examples of supported flag value types

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,16 +1,16 @@
 PODS:
-  - DarklyEventSource (2.0.0)
-  - LaunchDarkly (2.5.0):
-    - LaunchDarkly/Core (= 2.5.0)
-  - LaunchDarkly/Core (2.5.0):
-    - DarklyEventSource (~> 2.0.0)
+  - DarklyEventSource (3.0.0)
+  - LaunchDarkly (2.5.1):
+    - LaunchDarkly/Core (= 2.5.1)
+  - LaunchDarkly/Core (2.5.1):
+    - DarklyEventSource (~> 3.0.0)
 
 DEPENDENCIES:
   - LaunchDarkly
 
 SPEC CHECKSUMS:
-  DarklyEventSource: 710930f8f17e75abaf4d6c38a31a71718cc151e5
-  LaunchDarkly: 353cda167f33ca38d8281068dbb0800d8f2bac95
+  DarklyEventSource: e8ddf05b2098da7fd3acc60dc14e230df4fce311
+  LaunchDarkly: 7faea0bff9cb8e4c3de184ced8764240a50e49ce
 
 PODFILE CHECKSUM: e35353ee50b31e82c8a2f042337cd7577463de3f
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
-### LaunchDarkly Sample iOS Application  ###
-We've built a simple console application that demonstrates how LaunchDarkly's SDK works.  Below, you'll find the basic build procedure, but for more comprehensive instructions, you can visit your [Quickstart page](https://app.launchdarkly.com/quickstart#/).
-##### Build instructions  #####
-1. Make sure you have [XCode](https://itunes.apple.com/us/app/xcode/id497799835?ls=1&mt=12) installed
-2. Open `hello-ios.xcworkspace` in XCode
-3. Copy the mobile key from your account settings page and the feature flag key from your LaunchDarkly dashboard into `ViewController.m` 
-4. Run your application through XCode
+### LaunchDarkly Sample iOS Application
+We've built a simple console application that demonstrates how LaunchDarkly's SDK works. 
+Below, you'll find the basic build procedure, but for more comprehensive instructions, you can visit your [Quickstart page](https://app.launchdarkly.com/quickstart#/).
+##### Build instructions
+
+1. Make sure you have [XCode](https://itunes.apple.com/us/app/xcode/id497799835?ls=1&mt=12) and [CocoaPods](https://cocoapods.org) installed
+2. Make sure you're in this directory and then type `pod install`
+3. Open `hello-ios.xcworkspace` in XCode
+4. Copy the mobile key from your account settings page and the feature flag key(s) from your LaunchDarkly dashboard into `ViewController.m`
+5. Run your application through XCode

--- a/hello-ios/Base.lproj/Main.storyboard
+++ b/hello-ios/Base.lproj/Main.storyboard
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11762" systemVersion="16B2555" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="12121" systemVersion="16F73" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11757"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12089"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -20,25 +20,162 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Flag value:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Nsq-za-dwv">
-                                <rect key="frame" x="146.5" y="323" width="81.5" height="21"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="129-SV-EOH" userLabel="Boolea View">
+                                <rect key="frame" x="0.0" y="28" width="375" height="37"/>
+                                <subviews>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Boolean value:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Nsq-za-dwv">
+                                        <rect key="frame" x="8" y="8" width="111.5" height="21"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="?" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9JJ-sn-ODC">
+                                        <rect key="frame" x="358" y="8" width="9" height="21"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                </subviews>
+                                <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                <constraints>
+                                    <constraint firstItem="9JJ-sn-ODC" firstAttribute="top" secondItem="129-SV-EOH" secondAttribute="top" constant="8" id="5bQ-Ru-fJV"/>
+                                    <constraint firstItem="Nsq-za-dwv" firstAttribute="leading" secondItem="129-SV-EOH" secondAttribute="leading" constant="8" id="8c1-F2-IiF"/>
+                                    <constraint firstAttribute="bottom" secondItem="9JJ-sn-ODC" secondAttribute="bottom" constant="8" id="LqM-zm-WQs"/>
+                                    <constraint firstItem="9JJ-sn-ODC" firstAttribute="trailing" secondItem="129-SV-EOH" secondAttribute="trailing" constant="-8" id="Sst-zU-QGu"/>
+                                    <constraint firstItem="9JJ-sn-ODC" firstAttribute="top" secondItem="Nsq-za-dwv" secondAttribute="top" id="YU2-Yc-WVj"/>
+                                </constraints>
+                            </view>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Gta-Cg-QdV" userLabel="Number View">
+                                <rect key="frame" x="0.0" y="65" width="375" height="37"/>
+                                <subviews>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Number value:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="THY-Q4-dmO">
+                                        <rect key="frame" x="8" y="8" width="111" height="21"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="?" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xaA-BC-hg2">
+                                        <rect key="frame" x="358.5" y="8" width="8.5" height="21"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                </subviews>
+                                <color key="backgroundColor" red="0.90781013489999995" green="0.90781013489999995" blue="0.90781013489999995" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <constraints>
+                                    <constraint firstItem="xaA-BC-hg2" firstAttribute="top" secondItem="Gta-Cg-QdV" secondAttribute="top" constant="8" id="9gh-Fv-b8c"/>
+                                    <constraint firstItem="xaA-BC-hg2" firstAttribute="top" secondItem="THY-Q4-dmO" secondAttribute="top" id="HE8-sd-ohk"/>
+                                    <constraint firstItem="THY-Q4-dmO" firstAttribute="leading" secondItem="Gta-Cg-QdV" secondAttribute="leading" constant="8" id="NiO-44-hbN"/>
+                                    <constraint firstAttribute="bottom" secondItem="xaA-BC-hg2" secondAttribute="bottom" constant="8" id="QCi-JE-GXL"/>
+                                    <constraint firstItem="xaA-BC-hg2" firstAttribute="trailing" secondItem="Gta-Cg-QdV" secondAttribute="trailing" constant="-8" id="U36-mm-n47"/>
+                                </constraints>
+                            </view>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Rnk-UA-6WX" userLabel="String View">
+                                <rect key="frame" x="0.0" y="102" width="375" height="37"/>
+                                <subviews>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="String value:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Sbu-MQ-vj9">
+                                        <rect key="frame" x="8" y="8" width="95" height="21"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="?" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="SdZ-1p-fVg">
+                                        <rect key="frame" x="358" y="8" width="9" height="21"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                </subviews>
+                                <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                <constraints>
+                                    <constraint firstItem="Sbu-MQ-vj9" firstAttribute="leading" secondItem="Rnk-UA-6WX" secondAttribute="leading" constant="8" id="Amf-1a-nej"/>
+                                    <constraint firstItem="SdZ-1p-fVg" firstAttribute="trailing" secondItem="Rnk-UA-6WX" secondAttribute="trailing" constant="-8" id="TFf-So-W89"/>
+                                    <constraint firstItem="SdZ-1p-fVg" firstAttribute="top" secondItem="Sbu-MQ-vj9" secondAttribute="top" id="jSf-rR-zsJ"/>
+                                    <constraint firstAttribute="bottom" secondItem="SdZ-1p-fVg" secondAttribute="bottom" constant="8" id="qCD-qy-A6y"/>
+                                    <constraint firstItem="SdZ-1p-fVg" firstAttribute="top" secondItem="Rnk-UA-6WX" secondAttribute="top" constant="8" id="rkj-oO-okw"/>
+                                </constraints>
+                            </view>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="h74-6f-gMW" userLabel="Array View">
+                                <rect key="frame" x="0.0" y="139" width="375" height="36.5"/>
+                                <subviews>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Array value:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="sKt-Pk-Mz1">
+                                        <rect key="frame" x="8" y="8" width="90.5" height="21"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="?" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Cah-de-yNf">
+                                        <rect key="frame" x="358.5" y="8" width="8.5" height="20.5"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                </subviews>
+                                <color key="backgroundColor" red="0.90781013489999995" green="0.90781013489999995" blue="0.90781013489999995" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <constraints>
+                                    <constraint firstItem="Cah-de-yNf" firstAttribute="trailing" secondItem="h74-6f-gMW" secondAttribute="trailing" constant="-8" id="0Jd-ja-BsO"/>
+                                    <constraint firstItem="sKt-Pk-Mz1" firstAttribute="leading" secondItem="h74-6f-gMW" secondAttribute="leading" constant="8" id="7vo-Zc-G2q"/>
+                                    <constraint firstAttribute="bottom" secondItem="Cah-de-yNf" secondAttribute="bottom" constant="8" id="IAB-EC-P7H"/>
+                                    <constraint firstItem="Cah-de-yNf" firstAttribute="top" secondItem="h74-6f-gMW" secondAttribute="top" constant="8" id="KZ3-dx-Scn"/>
+                                    <constraint firstItem="Cah-de-yNf" firstAttribute="top" secondItem="sKt-Pk-Mz1" secondAttribute="top" id="xZh-1g-dzC"/>
+                                </constraints>
+                            </view>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="saF-xa-vJn" userLabel="Dictionary View">
+                                <rect key="frame" x="0.0" y="175.5" width="375" height="37"/>
+                                <subviews>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Dictionary value:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="q1g-1e-xL4">
+                                        <rect key="frame" x="8" y="8" width="128" height="21"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="?" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="dBz-mn-zLc">
+                                        <rect key="frame" x="358" y="8" width="9" height="21"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                </subviews>
+                                <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                <constraints>
+                                    <constraint firstItem="dBz-mn-zLc" firstAttribute="trailing" secondItem="saF-xa-vJn" secondAttribute="trailing" constant="-8" id="H89-ET-8oW"/>
+                                    <constraint firstItem="q1g-1e-xL4" firstAttribute="leading" secondItem="saF-xa-vJn" secondAttribute="leading" constant="8" id="VXa-7H-LB7"/>
+                                    <constraint firstItem="dBz-mn-zLc" firstAttribute="top" secondItem="q1g-1e-xL4" secondAttribute="top" id="fC3-Bk-4dy"/>
+                                    <constraint firstItem="dBz-mn-zLc" firstAttribute="top" secondItem="saF-xa-vJn" secondAttribute="top" constant="8" id="gNN-4v-O2w"/>
+                                    <constraint firstAttribute="bottom" secondItem="dBz-mn-zLc" secondAttribute="bottom" constant="8" id="jFk-5k-usJ"/>
+                                </constraints>
+                            </view>
                         </subviews>
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
-                            <constraint firstItem="Nsq-za-dwv" firstAttribute="centerY" secondItem="8bC-Xf-vdC" secondAttribute="centerY" id="bWe-z1-iZ9"/>
-                            <constraint firstItem="Nsq-za-dwv" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="xZ3-jK-LOL"/>
+                            <constraint firstItem="h74-6f-gMW" firstAttribute="leading" secondItem="8bC-Xf-vdC" secondAttribute="leading" id="1Wc-8f-8pg"/>
+                            <constraint firstAttribute="trailing" secondItem="h74-6f-gMW" secondAttribute="trailing" id="3B9-8l-zYZ"/>
+                            <constraint firstAttribute="trailing" secondItem="saF-xa-vJn" secondAttribute="trailing" id="BMV-cI-km7"/>
+                            <constraint firstItem="Rnk-UA-6WX" firstAttribute="leading" secondItem="8bC-Xf-vdC" secondAttribute="leading" id="DZ9-K8-wXu"/>
+                            <constraint firstAttribute="trailing" secondItem="Rnk-UA-6WX" secondAttribute="trailing" id="EQf-qO-p4V"/>
+                            <constraint firstItem="saF-xa-vJn" firstAttribute="leading" secondItem="8bC-Xf-vdC" secondAttribute="leading" id="IpX-U1-1v4"/>
+                            <constraint firstItem="129-SV-EOH" firstAttribute="leading" secondItem="8bC-Xf-vdC" secondAttribute="leading" id="Rrw-7C-V5b"/>
+                            <constraint firstItem="Gta-Cg-QdV" firstAttribute="top" secondItem="129-SV-EOH" secondAttribute="bottom" id="Vym-Wo-T7j"/>
+                            <constraint firstItem="h74-6f-gMW" firstAttribute="top" secondItem="Rnk-UA-6WX" secondAttribute="bottom" id="X8h-YV-Qxm"/>
+                            <constraint firstItem="saF-xa-vJn" firstAttribute="top" secondItem="h74-6f-gMW" secondAttribute="bottom" id="e3h-hK-SUU"/>
+                            <constraint firstItem="129-SV-EOH" firstAttribute="trailing" secondItem="8bC-Xf-vdC" secondAttribute="trailing" id="h5Y-VN-O6m"/>
+                            <constraint firstItem="Rnk-UA-6WX" firstAttribute="top" secondItem="Gta-Cg-QdV" secondAttribute="bottom" id="kXa-Oe-en5"/>
+                            <constraint firstAttribute="trailing" secondItem="Gta-Cg-QdV" secondAttribute="trailing" id="ros-bw-sH1"/>
+                            <constraint firstItem="Gta-Cg-QdV" firstAttribute="leading" secondItem="8bC-Xf-vdC" secondAttribute="leading" id="tHc-MQ-neW"/>
+                            <constraint firstItem="129-SV-EOH" firstAttribute="top" secondItem="y3c-jy-aDJ" secondAttribute="bottom" constant="8" symbolic="YES" id="ulb-jk-lGP"/>
                         </constraints>
                     </view>
                     <connections>
-                        <outlet property="valueLabel" destination="Nsq-za-dwv" id="lCD-H8-k3D"/>
+                        <outlet property="arrayValueLabel" destination="Cah-de-yNf" id="WzF-KX-O1y"/>
+                        <outlet property="booleanValueLabel" destination="9JJ-sn-ODC" id="xcp-DL-5zb"/>
+                        <outlet property="dictionaryValueLabel" destination="dBz-mn-zLc" id="BNR-4W-ijU"/>
+                        <outlet property="numberValueLabel" destination="xaA-BC-hg2" id="zGm-LC-s2j"/>
+                        <outlet property="stringValueLabel" destination="SdZ-1p-fVg" id="ODO-ys-Byq"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>
+            <point key="canvasLocation" x="136.80000000000001" y="138.98050974512745"/>
         </scene>
     </scenes>
 </document>

--- a/hello-ios/ViewController.h
+++ b/hello-ios/ViewController.h
@@ -10,7 +10,11 @@
 
 @interface ViewController : UIViewController
 
-@property (weak, nonatomic) IBOutlet UILabel *valueLabel;
+@property (weak, nonatomic) IBOutlet UILabel *booleanValueLabel;
+@property (weak, nonatomic) IBOutlet UILabel *numberValueLabel;
+@property (weak, nonatomic) IBOutlet UILabel *stringValueLabel;
+@property (weak, nonatomic) IBOutlet UILabel *arrayValueLabel;
+@property (weak, nonatomic) IBOutlet UILabel *dictionaryValueLabel;
 
 @end
 

--- a/hello-ios/ViewController.m
+++ b/hello-ios/ViewController.m
@@ -9,12 +9,12 @@
 #import "ViewController.h"
 #import "Darkly.h"
 
-NSString *MOBILE_KEY = @"mob-b9b5e098-aa3d-4049-b8fe-64abc39cd7d9";
-NSString *BOOLEAN_FLAG_KEY = @"my-boolean";
-NSString *NUMBER_FLAG_KEY = @"my-number";
-NSString *STRING_FLAG_KEY = @"my-string";
-NSString *ARRAY_FLAG_KEY = @"my-array";
-NSString *DICTIONARY_FLAG_KEY = @"my-dictionary";
+NSString *MOBILE_KEY = @"";
+NSString *BOOLEAN_FLAG_KEY = @"hello-ios-boolean";
+NSString *NUMBER_FLAG_KEY = @"hello-ios-number";
+NSString *STRING_FLAG_KEY = @"hello-ios-string";
+NSString *ARRAY_FLAG_KEY = @"hello-ios-array";
+NSString *DICTIONARY_FLAG_KEY = @"hello-ios-dictionary";
 
 @interface ViewController () <ClientDelegate>
 
@@ -58,7 +58,7 @@ NSString *DICTIONARY_FLAG_KEY = @"my-dictionary";
 }
 
 - (void)checkNumberFeatureValue {
-    double numberFeature = [[LDClient sharedInstance] doubleVariation:NUMBER_FLAG_KEY fallback:0];
+    double numberFeature = [[[LDClient sharedInstance] numberVariation:NUMBER_FLAG_KEY fallback:@0] doubleValue];
     [self updateLabel:_numberValueLabel withText:[NSString stringWithFormat:@"%f",numberFeature]];
 }
 
@@ -68,12 +68,12 @@ NSString *DICTIONARY_FLAG_KEY = @"my-dictionary";
 }
 
 - (void)checkArrayFeatureValue {
-    NSArray *arrayFeature = [[LDClient sharedInstance] arrayVariation:ARRAY_FLAG_KEY fallback:[NSArray array]];
+    NSArray *arrayFeature = [[LDClient sharedInstance] arrayVariation:ARRAY_FLAG_KEY fallback:@[@0,@1]];
     [self updateLabel:_arrayValueLabel withText:[arrayFeature componentsJoinedByString:@"\n"]];
 }
 
 - (void)checkDictionaryFeatureValue {
-    NSDictionary *dictionaryFeature = [[LDClient sharedInstance] dictionaryVariation:DICTIONARY_FLAG_KEY fallback:[NSDictionary dictionary]];
+    NSDictionary *dictionaryFeature = [[LDClient sharedInstance] dictionaryVariation:DICTIONARY_FLAG_KEY fallback:@{@"dictionary":@"fallback"}];
     NSMutableArray *elems = [NSMutableArray arrayWithCapacity:dictionaryFeature.count];
     [dictionaryFeature enumerateKeysAndObjectsUsingBlock:^(id  _Nonnull key, id  _Nonnull obj, BOOL * _Nonnull stop) {
         [elems addObject:[NSString stringWithFormat:@"\"%@\": %@", key, obj]];

--- a/hello-ios/ViewController.m
+++ b/hello-ios/ViewController.m
@@ -10,7 +10,11 @@
 #import "Darkly.h"
 
 NSString *MOBILE_KEY = @"mob-b9b5e098-aa3d-4049-b8fe-64abc39cd7d9";
-NSString *FLAG_KEY = @"main-slider";
+NSString *BOOLEAN_FLAG_KEY = @"my-boolean";
+NSString *NUMBER_FLAG_KEY = @"my-number";
+NSString *STRING_FLAG_KEY = @"my-string";
+NSString *ARRAY_FLAG_KEY = @"my-array";
+NSString *DICTIONARY_FLAG_KEY = @"my-dictionary";
 
 @interface ViewController () <ClientDelegate>
 
@@ -44,23 +48,69 @@ NSString *FLAG_KEY = @"main-slider";
     LDConfig *config = [[LDConfig alloc] initWithMobileKey:MOBILE_KEY];
     config.debugEnabled = YES;
     
+    [[LDClient sharedInstance] setDelegate:self];
     [[LDClient sharedInstance] start:config withUserBuilder:builder];
 }
 
-- (void)checkFeatureValue {
-    BOOL showFeature = [[LDClient sharedInstance] boolVariation:FLAG_KEY fallback:NO];
-    [self updateLabel:[NSString stringWithFormat:@"%d",showFeature]];
+- (void)checkBoolFeatureValue {
+    BOOL boolFeature = [[LDClient sharedInstance] boolVariation:BOOLEAN_FLAG_KEY fallback:NO];
+    [self updateLabel:_booleanValueLabel withText:boolFeature ? @"YES" : @"NO"];
 }
 
-- (void)updateLabel:(NSString *)value {
-    self.valueLabel.text = [NSString stringWithFormat:@"Flag value: %@",value];
+- (void)checkNumberFeatureValue {
+    double numberFeature = [[LDClient sharedInstance] doubleVariation:NUMBER_FLAG_KEY fallback:0];
+    [self updateLabel:_numberValueLabel withText:[NSString stringWithFormat:@"%f",numberFeature]];
+}
+
+- (void)checkStringFeatureValue {
+    NSString *stringFeature = [[LDClient sharedInstance] stringVariation:STRING_FLAG_KEY fallback:@"<no default>"];
+    [self updateLabel:_stringValueLabel withText:stringFeature];
+}
+
+- (void)checkArrayFeatureValue {
+    NSArray *arrayFeature = [[LDClient sharedInstance] arrayVariation:ARRAY_FLAG_KEY fallback:[NSArray array]];
+    [self updateLabel:_arrayValueLabel withText:[arrayFeature componentsJoinedByString:@"\n"]];
+}
+
+- (void)checkDictionaryFeatureValue {
+    NSDictionary *dictionaryFeature = [[LDClient sharedInstance] dictionaryVariation:DICTIONARY_FLAG_KEY fallback:[NSDictionary dictionary]];
+    NSMutableArray *elems = [NSMutableArray arrayWithCapacity:dictionaryFeature.count];
+    [dictionaryFeature enumerateKeysAndObjectsUsingBlock:^(id  _Nonnull key, id  _Nonnull obj, BOOL * _Nonnull stop) {
+        [elems addObject:[NSString stringWithFormat:@"\"%@\": %@", key, obj]];
+    }];
+    [self updateLabel:_dictionaryValueLabel withText:[elems componentsJoinedByString:@"\n"]];
+}
+
+- (void)checkFeatureValue {
+    [self checkBoolFeatureValue];
+    [self checkNumberFeatureValue];
+    [self checkStringFeatureValue];
+    [self checkArrayFeatureValue];
+    [self checkDictionaryFeatureValue];
+}
+
+- (void)updateLabel:(UILabel *)label withText:(NSString *)value {
+    if (value == nil) {
+        value = @"<nil>";
+    } else if (value.length == 0) {
+        value = @" ";
+    }
+    label.text = value;
 }
 
 #pragma mark - ClientDelegate methods
 
 -(void)featureFlagDidUpdate:(NSString *)key {
-    if([key isEqualToString:FLAG_KEY]) {
-        [self checkFeatureValue];
+    if([key isEqualToString:BOOLEAN_FLAG_KEY]) {
+        [self checkBoolFeatureValue];
+    } else if([key isEqualToString:NUMBER_FLAG_KEY]) {
+        [self checkNumberFeatureValue];
+    } else if([key isEqualToString:STRING_FLAG_KEY]) {
+        [self checkStringFeatureValue];
+    } else if([key isEqualToString:ARRAY_FLAG_KEY]) {
+        [self checkArrayFeatureValue];
+    } else if([key isEqualToString:DICTIONARY_FLAG_KEY]) {
+        [self checkDictionaryFeatureValue];
     }
 }
 


### PR DESCRIPTION
Adds samples of supported flag value types: boolean, number, string, array, and dictionary.

Thanks to Glenn Austin for the suggestion and base implementation

NOTE: Do not merge until 2.5.1 PR has been merged.