### PR TITLE
ci: fix build by adding pod install and pipefail

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,9 @@ jobs:
         with:
           xcode-version: 16.4
 
+      - name: Install CocoaPods dependencies
+        run: pod install
+
       - name: Build hello-ios
         run: set -o pipefail && xcodebuild build -workspace 'hello-ios.xcworkspace' -scheme 'hello-ios' CODE_SIGNING_ALLOWED=NO | xcpretty
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
           xcode-version: 16.4
 
       - name: Build hello-ios
-        run: xcodebuild build -workspace 'hello-ios.xcworkspace' -scheme 'hello-ios' CODE_SIGNING_ALLOWED=NO | xcpretty
+        run: set -o pipefail && xcodebuild build -workspace 'hello-ios.xcworkspace' -scheme 'hello-ios' CODE_SIGNING_ALLOWED=NO | xcpretty
 
       - name: Build hello-watchOS
-        run: xcodebuild build -workspace 'hello-ios.xcworkspace' -scheme 'hello-watchOS' CODE_SIGNING_ALLOWED=NO | xcpretty
+        run: set -o pipefail && xcodebuild build -workspace 'hello-ios.xcworkspace' -scheme 'hello-watchOS' CODE_SIGNING_ALLOWED=NO | xcpretty


### PR DESCRIPTION
## Summary

The CI build was silently failing for two reasons:

1. **Missing `pod install`**: When the vendored `Pods/` directory was removed (commit 9a0eedb), a `pod install` step was never added to CI. The xcworkspace references `Pods/Pods.xcodeproj` which doesn't exist without it.

2. **Missing `pipefail`**: Piping `xcodebuild` to `xcpretty` without `set -o pipefail` meant the pipeline exit code came from `xcpretty` (always 0), masking the build failure.

Fixes both issues so CI correctly installs dependencies and reports failures.

Link to Devin session: https://app.devin.ai/sessions/5b1fe090ca3247c9a9e594a426c3a8ef
Requested by: @kinyoklion