### PR TITLE
chore: update LaunchDarkly iOS SDK to 11.2

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -1,10 +1,10 @@
 use_frameworks!
 target 'hello-ios' do
     platform :ios, '13.0'
-    pod 'LaunchDarkly', '>= 9.6'
+    pod 'LaunchDarkly', '>= 11.2'
 end
 
 target 'hello-watchOS Extension' do
     platform :watchos, '6.0'
-    pod 'LaunchDarkly', '>= 9.6'
+    pod 'LaunchDarkly', '>= 11.2'
 end

--- a/hello-common/LDClientConfigurator.m
+++ b/hello-common/LDClientConfigurator.m
@@ -18,7 +18,7 @@ NSString * const sdkKey = @"";
         LDConfig *config = [[LDConfig alloc]
                             initWithMobileKey:sdkKey autoEnvAttributes:true];
 
-        [LDClient startWithConfiguration:config context:result.success completion: nil];
+        [LDClient startWithConfiguration:config context:result.success startWaitSeconds:5 completion:nil];
     }
 }
 


### PR DESCRIPTION
## Summary

Updates the LaunchDarkly iOS SDK minimum version constraint from `>= 9.6` to `>= 11.2` (latest stable: 11.2.0).

**Deprecated API fix:** Updated `LDClient startWithConfiguration:context:completion:` to use `startWithConfiguration:context:startWaitSeconds:completion:` with a 5-second timeout, as the no-timeout variant was deprecated in SDK 9.6.1.

Changes are split into two commits:
1. Fix deprecated API usage (using existing dependency version)
2. Bump SDK version constraint in Podfile

Link to Devin session: https://app.devin.ai/sessions/e526397b85be4331b200fff0fe50d984
Requested by: @kinyoklion

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency version bump and a single demo startup call change with no auth or data-handling impact.
> 
> **Overview**
> Bumps the **LaunchDarkly** CocoaPods constraint from `>= 9.6` to **`>= 11.2`** for both the **hello-ios** and **hello-watchOS Extension** targets.
> 
> In `LDClientConfigurator`, client startup now uses **`startWithConfiguration:context:startWaitSeconds:completion:`** with **`startWaitSeconds:5`** instead of the deprecated no-timeout **`startWithConfiguration:context:completion:`** API.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cadd729e6faeb1cb927ae3372a80610eaeec5def. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->